### PR TITLE
Update imagetag setting

### DIFF
--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -118,7 +118,24 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+      - name: Get package versions
+        uses: octokit/request-action@v2.x
+        id: get_package_versions
+        with:
+          route: GET /user/packages/container/altinn-access-management-frontend/versions
+          mediaType: | # The | is significant!
+            format: raw
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Get latest imagetag
+        id: get_imagetag
+        run: |
+         responses='${{ steps.get_package_versions.outputs.data }}'
+         echo $responses | jq '.[0] | .metadata.container.tags[0]' | sed 's/"//g'
+         latesttag=$(echo $responses | jq '.[0] | .metadata.container.tags[0]' | sed 's/"//g')
+         echo "version:$latesttag"         
+         echo "imagetag=$latesttag" >> $GITHUB_OUTPUT
       - id: version
         uses: battila7/get-version-action@v2
       - name: Add Version tag to Docker Image
@@ -126,7 +143,7 @@ jobs:
         with:
           registry: ${{ env.REGISTRY }}
           repository: '${{ env.IMAGE_NAME }}'
-          target: '${{ steps.get_commit_sha.outputs.commitid }}'
+          target: '${{ steps.get_imagetag.outputs.imagetag }}'
           tags: ${{ needs.getlatestrelease.outputs.RELEASEVERSION }}
 
   update_release_draft:


### PR DESCRIPTION
Currently, When a release is scheduled, it creates a new release version, draft release notes and tags the latest image with the release version. We were finding the latest image by the commit id. But when we commit to for.example workflows, it will not trigger the image building action. Therefore now we will get the latest image by listing the github packages api and then extract the element at 0 position and extract the tag at 0 position aswell.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
